### PR TITLE
Use pluginConfig instead of Aurelia config

### DIFF
--- a/src/aurelia-redux-plugin.ts
+++ b/src/aurelia-redux-plugin.ts
@@ -4,7 +4,7 @@ import { Store, ReduxPluginConfig } from './Store';
 
 export function configure<S>(config: any, pluginConfig: ReduxPluginConfig<S>): void {
   const container = config.container as Container;
-  const store = container.invoke(Store, [config]);
+  const store = container.invoke(Store, [pluginConfig]);
 
   container.registerInstance(Store, store);
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -65,7 +65,8 @@ export function dispatch<T extends Redux.Action, S>(actionCreator: string|Action
       if (isString(options.creator) && isFunction(target[options.creator])) {
         return target[options.creator].call(target, _dispatch, ...args);
       } else if (isFunction(options.creator)) {
-        return options.creator(_dispatch, ...args);
+        const creatorFunction = options.creator as Function;
+        return creatorFunction(_dispatch, ...args);
       }
 
       return _dispatch(...args);


### PR DESCRIPTION
As noted in #10 the aurelia-redux-plugin passes Aurelia's configuration to the Store class, but that class expects a ReduxPluginConfig instead. This PR fixes that so that creating the store in an application's main.ts works as expected.

Note: I had to make the other change to dispatch.ts in order to get things to compile.