### PR TITLE
Skip change detection if Redux DevTools are connected

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -19,6 +19,7 @@ export class Store<S> {
 
   private store: Redux.Store<S>;
   private _changeId: number = 0;
+  private _devToolsConnected: boolean = false;
   
   constructor(
     private bindingEngine: BindingEngine,
@@ -31,10 +32,24 @@ export class Store<S> {
     if (this.config.store) {
       this.provideStore(this.config.store);
     }
+
+    if (window.__REDUX_DEVTOOLS_EXTENSION__) {
+      window.__REDUX_DEVTOOLS_EXTENSION__.listen(({type}: any) => {
+        if (type === 'START') {
+          this._devToolsConnected = true;
+        } else if (type === 'STOP') {
+          this._devToolsConnected = false;
+        }
+      });
+    }
   }
 
   get changeId(): number {
     return this._changeId;
+  }
+
+  get devToolsConnected(): boolean {
+    return this._devToolsConnected;
   }
 
   provideStore(store: Redux.Store<S>): void {

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -65,7 +65,8 @@ export function dispatch<T extends Redux.Action, S>(actionCreator: string|Action
       if (isString(options.creator) && isFunction(target[options.creator])) {
         return target[options.creator].call(target, _dispatch, ...args);
       } else if (isFunction(options.creator)) {
-        return options.creator(_dispatch, ...args);
+        const dispatcher = options.creator as Function;
+        return dispatcher(_dispatch, ...args);
       }
 
       return _dispatch(...args);

--- a/src/select.ts
+++ b/src/select.ts
@@ -92,7 +92,7 @@ export function select<S, T>(selector?: string|Array<string|number>|StoreSelecto
       
       let value = lastValue;
       
-      if (Store.instance.changeId !== lastChangeId) {
+      if (Store.instance.changeId !== lastChangeId || Store.instance.devToolsConnected) {
         value = Store.instance.select(selector as StoreSelector<S, T>, this, { invoke: config.invoke });
         lastValue = value;
         lastChangeId = Store.instance.changeId;


### PR DESCRIPTION
As described in #11 the change detection mechanism that's currently in place causes the view not to update when the DevTools are being used. This PR suppresses the change detection mechanism when the devTools connect, and restores it when the devTools disconnect again. A similar mechanism exists in ng2-redux as can be seen [here](https://github.com/angular-redux/store/blob/master/src/components/dev-tools.ts)